### PR TITLE
Update proc_starting-monitoring-alerting-telemetry.adoc

### DIFF
--- a/docs/source/topics/proc_starting-monitoring-alerting-telemetry.adoc
+++ b/docs/source/topics/proc_starting-monitoring-alerting-telemetry.adoc
@@ -11,7 +11,7 @@ Telemetry functionality is responsible for listing your cluster in the link:http
 For more information, see link:{crc-gsg-url}#accessing-the-openshift-cluster-with-oc_gsg[Accessing the OpenShift cluster with `oc`].
 * You must log in through [command]`oc` as the `kubeadmin` user.
 * You must assign additional memory to the {prod} virtual machine.
-At least 12 GiB of memory (a value of `12288`) is recommended.
+At least 20 GiB of memory (a value of `20480`) is recommended.
 For more information, see link:{crc-gsg-url}#configuring-the-virtual-machine_gsg[Configuring the virtual machine].
 
 .Procedure


### PR DESCRIPTION
## Solution/Idea

Using 12GB was insufficient and resulted in insufficient memory errors.

## Proposed changes

Update recommended size to 20 GB

## Testing

1.Install crc with monitoring, alerting and telemetry enabled with 12GB
Compared to 20GB.
2. Check for insufficient memory errors in the ui.